### PR TITLE
Adds unescaping html entities in inspections

### DIFF
--- a/src/main/kotlin/com/chylex/intellij/inspectionlens/LensRenderer.kt
+++ b/src/main/kotlin/com/chylex/intellij/inspectionlens/LensRenderer.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInsight.daemon.impl.HintRenderer
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.Inlay
 import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.util.text.StringUtil
 import java.awt.Font
 import java.awt.Graphics
 import java.awt.Rectangle
@@ -41,7 +42,7 @@ class LensRenderer(info: HighlightInfo) : HintRenderer(null) {
 		private val ATTRIBUTES_SINGLETON = TextAttributes(null, null, null, null, Font.ITALIC)
 		
 		private fun getValidDescriptionText(text: String?): String {
-			return if (text.isNullOrBlank()) " " else addMissingPeriod(text)
+			return if (text.isNullOrBlank()) " " else StringUtil.unescapeXmlEntities(addMissingPeriod(text))
 		}
 		
 		private fun addMissingPeriod(text: String): String {


### PR DESCRIPTION
Some of the `eslint` errors are formatted as an html code and some of special characters are encoded as html entities. `StringUtil.unescapeXmlEntities` converts entities to normal characters. 

Before (see this `&quot;`):
![Screenshot 2022-10-03 at 09 11 01](https://user-images.githubusercontent.com/35625949/193530933-39726a5b-fd76-4442-ae30-d16a5217bc44.png)

After:
![Screenshot 2022-10-03 at 10 14 20](https://user-images.githubusercontent.com/35625949/193530962-ca4ae9da-54f8-4c7f-b0e9-60d2b55bdb3a.png)
